### PR TITLE
INF-512: Version headers in Java connector are not aligned with lib version 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Java Wrapper for Loop54 JSON V3 API
 ## How to install
 Either download any of these jars for the desired version and import them into you project:
 
-* [loop54-core-2.0.1.jar](https://static.loop54.com/lib/java/core/loop54-core-2.0.1.jar) - **Core** functionality **without** its dependencies
-* [loop54-core-all-2.0.1.jar](https://static.loop54.com/lib/java/core/loop54-core-all-2.0.1.jar) - **Core** functionality **with** all its dependencies 
-* [loop54-spring-2.0.1.jar](https://static.loop54.com/lib/java/spring/loop54-spring-2.0.1.jar) - **Core** functionality **plus Spring** specific implementation **without** its dependencies
-* [loop54-spring-all-2.0.1.jar](https://static.loop54.com/lib/java/spring/loop54-spring-all-2.0.1.jar) - **Core** functionality **plus Spring** specific implementation **with** all its dependencies
+* [loop54-core-5.0.1.jar](https://static.loop54.com/lib/java/core/loop54-core-5.0.1.jar) - **Core** functionality **without** its dependencies
+* [loop54-core-all-5.0.1.jar](https://static.loop54.com/lib/java/core/loop54-core-all-5.0.1.jar) - **Core** functionality **with** all its dependencies 
+* [loop54-spring-5.0.1.jar](https://static.loop54.com/lib/java/spring/loop54-spring-5.0.1.jar) - **Core** functionality **plus Spring** specific implementation **without** its dependencies
+* [loop54-spring-all-5.0.1.jar](https://static.loop54.com/lib/java/spring/loop54-spring-all-5.0.1.jar) - **Core** functionality **plus Spring** specific implementation **with** all its dependencies
 
 Or download the source and reference the core and spring modules and build it using gradle.
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 ext {
-    projectVersion = '2.0.1'
+    projectVersion = '5.0.1'
     versions = [
         spring              : '7.0.3',
         jakartaServlet      : '6.1.0',
@@ -43,6 +43,10 @@ subprojects {
         test {
             useJUnitPlatform()
         }
+
+        tasks.named('build') {
+            dependsOn rootProject.tasks.named('checkVersionHeaders')
+        }
     }
 }
 
@@ -60,6 +64,16 @@ tasks.register("generateReadme") {
     }
 }
 
+def resolveVersionHeadersFile = {
+    fileTree(rootDir).matching {
+        include "**/VersionHeaders.java"
+        exclude "**/build/**"
+        exclude "**/test/**"
+    }.singleFile
+}
+
+def libVersionPattern = /LIB_VERSION\s*=\s*"Java:[^"]*"/
+
 tasks.register("setVersion") {
     description = "Sets the project version. Usage: ./gradlew setVersion -PnewVersion=x.y.z"
 
@@ -73,9 +87,29 @@ tasks.register("setVersion") {
         def content = buildFile.text
         def updated = content.replaceFirst(/projectVersion\s*=\s*'[^']*'/, "projectVersion = '${newVersion}'")
         buildFile.text = updated
+        def versionHeadersFile = resolveVersionHeadersFile()
+        versionHeadersFile.text = versionHeadersFile.text.replaceFirst(libVersionPattern, "LIB_VERSION = \"Java:${newVersion}\"")
+
         // Update ext property for generateReadme task
         ext.projectVersion = newVersion
         println "Version updated to ${newVersion}"
+    }
+}
+
+tasks.register("checkVersionHeaders") {
+    description = "Check that LIB_VERSION in VersionHeaders.java matches projectVersion in build.gradle"
+    doLast {
+        def versionHeadersFileContent = resolveVersionHeadersFile().text
+        def match = versionHeadersFileContent =~ libVersionPattern
+        if (!match) {
+            throw new GradleException("Could not find LIB_VERSION in VersionHeaders.java")
+        }
+        def libVersion = (versionHeadersFileContent =~ /LIB_VERSION\s*=\s*"Java:([^"]*)"/)[ 0][1]
+        if (libVersion != projectVersion) {
+            throw new GradleException("Version mismatch: LIB_VERSION is 'Java:${libVersion}' but projectVersion is '${projectVersion}'. " +
+                "Run: ./gradlew setVersion -PnewVersion=${projectVersion}")
+        }
+        println "Version check passed: ${projectVersion}"
     }
 }
 

--- a/core/src/main/java/com/loop54/VersionHeaders.java
+++ b/core/src/main/java/com/loop54/VersionHeaders.java
@@ -7,5 +7,5 @@ public class VersionHeaders {
     public static final String API_VERSION = "V3";
 
     public static final String LIB_VERSION_HEADER = "Lib-Version";
-    public static final String LIB_VERSION = "Java:5.0.1"; // TODO: populate with semantic version
+    public static final String LIB_VERSION = "Java:5.0.1";
 }


### PR DESCRIPTION
Added code in gradle task `setVersion -PnewVersion=X.x.x` to set LIB_VERSION in VersionHeaders.java to the same version as the project
Added additional gradle task `checkVersionHeaders` to check that LIB_VERSION and projectVersion match

**Testing:**
When running `./gradlew setVersion "-PnewVersion=X.X.X"` with a specific version, the same version is also applied to `VersionHeaders.java`.

Additionally, if the version is changed manually (either in `projectVersion` or `LIB_VERSION`), running `./gradlew build` will produce an erorr message (build failed) indicating that the versions do not match, for example:

`Version mismatch: LIB_VERSION is 'Java:5.0.1' but projectVersion is '8.0.1'. Run: ./gradlew setVersion -PnewVersion=8.0.1`
